### PR TITLE
Pin to last known working version: v2.13.32

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,14 +11,21 @@ function indent() {
   esac
 }
 
-AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+AWS_CLI_VERSION="2.13.32"
+
+if [ -n "${AWS_CLI_VERSION+x}" ]; then
+  echo "-----> AWS CLI version pinned to ${AWS_CLI_VERSION}"
+  AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip"
+else
+  AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+fi
 
 BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"
 INSTALL_DIR="/app/.awscli"
 TMP_DIR=$(mktemp -d)
 
-echo "-----> Downloading AWS CLI"
+echo "-----> Downloading AWS CLI ${AWS_CLI_URL}"
 curl --silent --show-error --fail -o "${TMP_DIR}/awscliv2.zip" "${AWS_CLI_URL}" |& indent
 unzip -qq -d "${TMP_DIR}" "${TMP_DIR}/awscliv2.zip" |& indent
 


### PR DESCRIPTION
Upstream issue: https://github.com/heroku/heroku-buildpack-awscli/issues/19

---

This branch avoids compile errors on the latest AWS CLI release that [cause deploys to fail](https://dashboard.heroku.com/apps/statushero-5e78e4ca0/activity/builds/3737a486-9eee-45f7-978d-24e76e0827ee):

<details><summary>💥</summary>

```
=== Fetching and vendoring Heroku CLI into slug
=== Installing profile.d script
 ›   Warning: Our terms of service have changed: 
 ›   https://dashboard.heroku.com/terms-of-service
heroku/7.69.1 linux-x64 node-v14.19.0
=== Heroku CLI installation done
-----> AWS CLI app detected
-----> Downloading AWS CLI
-----> Installing AWS CLI
       Fatal error condition occurred in /tmp/pip-install-90cp_aq0/awscrt_d52d3579cb5e4eb1a9ee6f8f288622f3/crt/aws-c-common/source/allocator.c:187: num != 0 && size != 0
       Exiting Application
       ################################################################################
       Stack trace:
       ################################################################################
       /tmp/tmp.iLEAoFYJT0/aws/dist/_awscrt.abi3.so(aws_backtrace_print+0x4d) [0x7fb4c83dee6d]
       /tmp/tmp.iLEAoFYJT0/aws/dist/_awscrt.abi3.so(aws_fatal_assert+0x44) [0x7fb4c83d2cc4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/_awscrt.abi3.so(aws_mem_calloc+0xee) [0x7fb4c83d1f7e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/_awscrt.abi3.so(aws_s3_platform_info_loader_new+0x88) [0x7fb4c83285f8]
       /tmp/tmp.iLEAoFYJT0/aws/dist/_awscrt.abi3.so(aws_s3_library_init+0x52) [0x7fb4c831fd52]
       /tmp/tmp.iLEAoFYJT0/aws/dist/_awscrt.abi3.so(PyInit__awscrt+0x10b) [0x7fb4c831700b]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2ac245) [0x7fb4cea12245]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2a8141) [0x7fb4cea0e141]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x1bf310) [0x7fb4ce925310]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7fb4ce8cfb9d]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7fb4ce86df6c]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x274998) [0x7fb4ce9da998]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x1bf0a1) [0x7fb4ce9250a1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7fb4ce8cfb9d]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7fb4ce86df6c]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x2dc) [0x7fb4cea10dec]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fb4ce9dc1c4]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fb4ce86cb8e]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x27b415) [0x7fb4ce9e1415]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fb4ce8d06f0]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fb4ce8d08ca]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fb4cea110c1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fb4ce870ec1]
       /tmp/tmp.iLEAoFYJT0/aws/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fb4ce9e12a5]
       /tmp/tmp.iLEAoFYJT0/aws/dist/aws() [0x40332d]
       /tmp/tmp.iLEAoFYJT0/aws/dist/aws() [0x403675]
       /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fb4cef74083]
       /tmp/tmp.iLEAoFYJT0/aws/dist/aws() [0x401d11]
       Aborted
       You can now run: /app/.awscli/bin/aws --version
       Fatal error condition occurred in /tmp/pip-install-90cp_aq0/awscrt_d52d3579cb5e4eb1a9ee6f8f288622f3/crt/aws-c-common/source/allocator.c:187: num != 0 && size != 0
       Exiting Application
       ################################################################################
       Stack trace:
       ################################################################################
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_backtrace_print+0x4d) [0x7fd826588e6d]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_fatal_assert+0x44) [0x7fd82657ccc4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_mem_calloc+0xee) [0x7fd82657bf7e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_s3_platform_info_loader_new+0x88) [0x7fd8264d25f8]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(aws_s3_library_init+0x52) [0x7fd8264c9d52]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/_awscrt.abi3.so(PyInit__awscrt+0x10b) [0x7fd8264c100b]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2ac245) [0x7fd82cbbc245]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2a8141) [0x7fd82cbb8141]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x1bf310) [0x7fd82cacf310]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7fd82ca79b9d]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7fd82ca17f6c]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x274998) [0x7fd82cb84998]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x1bf0a1) [0x7fd82cacf0a1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyObject_Call+0x4d) [0x7fd82ca79b9d]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x76ac) [0x7fd82ca17f6c]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x2dc) [0x7fd82cbbadec]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x2761c4) [0x7fd82cb861c4]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0x62ce) [0x7fd82ca16b8e]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x27b415) [0x7fd82cb8b415]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(+0x16a6f0) [0x7fd82ca7a6f0]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyObject_CallMethodObjArgs+0xfa) [0x7fd82ca7a8ca]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyImport_ImportModuleLevelObject+0x5b1) [0x7fd82cbbb0c1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(_PyEval_EvalFrameDefault+0xa601) [0x7fd82ca1aec1]
       /tmp/build_223d62ad/.awscli/aws-cli/v2/dist/libpython3.11.so.1.0(PyEval_EvalCode+0x1f5) [0x7fd82cb8b2a5]
       /app/.awscli/bin/aws() [0x40332d]
       /app/.awscli/bin/aws() [0x403675]
       /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7fd82d11e083]
       /app/.awscli/bin/aws() [0x401d11]
/tmp/codon/tmp/buildpacks/f63d6152cde8512eb29ea911e39cc78d0d63f35b/bin/compile: line 41:  2408 Aborted                 /app/.awscli/bin/aws --version 2>&1
      2409 Done                    | indent
 !     Push rejected, failed to compile AWS CLI app.
 !     Push failed
```

</details>

References:
- https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html
- https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
- https://statushero.slack.com/archives/C03FDQZVCJV/p1699644941671709

---

Buildpack URL:
```
https://github.com/statushero/heroku-buildpack-awscli.git#pin-to-v2.13.32
```
